### PR TITLE
various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^4.0.0"
       },
       "devDependencies": {
-        "@applitools/eyes-playwright": "1.30.2",
+        "@applitools/eyes-playwright": "1.32.0",
         "@playwright/test": "^1.48.2",
         "@types/mocha": "^10.0.6",
         "@types/node": "20.2.5",
@@ -94,25 +94,26 @@
       "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/@applitools/core": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@applitools/core/-/core-4.22.1.tgz",
-      "integrity": "sha512-xBi6M6PF3rAwXhBmOm3fowuE6tsy7Ux45e+oUutTg8qobrNEF5xLtLCiVNEtIA46dVjPJroMKerzgf56/psGSw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@applitools/core/-/core-4.24.0.tgz",
+      "integrity": "sha512-KBQFxmd1sSky4QkoubAO3AL+/1RA6XxBfXcC5mNe5BS1u7LV4UJkyNfGRi9rXHCiSM9NVQeNMEAbMdUUAGGOwA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/core-base": "1.19.1",
-        "@applitools/dom-capture": "11.5.0",
-        "@applitools/dom-snapshot": "4.11.6",
-        "@applitools/driver": "1.19.6",
-        "@applitools/ec-client": "1.9.12",
-        "@applitools/logger": "2.0.18",
-        "@applitools/nml-client": "1.8.16",
-        "@applitools/req": "1.7.2",
-        "@applitools/screenshoter": "3.9.4",
-        "@applitools/snippets": "2.6.1",
-        "@applitools/socket": "1.1.18",
-        "@applitools/spec-driver-webdriver": "1.1.18",
-        "@applitools/ufg-client": "1.13.1",
-        "@applitools/utils": "1.7.4",
+        "@applitools/core-base": "1.19.2",
+        "@applitools/dom-capture": "11.5.1",
+        "@applitools/dom-snapshot": "4.11.9",
+        "@applitools/driver": "1.20.0",
+        "@applitools/ec-client": "1.9.14",
+        "@applitools/logger": "2.0.19",
+        "@applitools/nml-client": "1.8.18",
+        "@applitools/req": "1.7.3",
+        "@applitools/screenshoter": "3.10.0",
+        "@applitools/snippets": "2.6.2",
+        "@applitools/socket": "1.1.19",
+        "@applitools/spec-driver-webdriver": "1.1.20",
+        "@applitools/ufg-client": "1.14.0",
+        "@applitools/utils": "1.7.5",
         "@types/ws": "8.5.5",
         "abort-controller": "3.0.0",
         "chalk": "4.1.2",
@@ -131,15 +132,16 @@
       }
     },
     "node_modules/@applitools/core-base": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@applitools/core-base/-/core-base-1.19.1.tgz",
-      "integrity": "sha512-Eldb6mcfTNBH7yx/HpQdFEmQl9QcgdpG+/n+GPIGhRDgPpcHKI1EROYIwd92GNOT3tihzq+jKQ3nzrZaZrhlXQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@applitools/core-base/-/core-base-1.19.2.tgz",
+      "integrity": "sha512-i//J8KlYB9cduXl8yMPpTRwM4vCRcNQltCNrC9YXDL4qAxZep27RXoLq3lZtKyxfAFcC3ddbrvI8o+r73Q4+7g==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/image": "1.1.13",
-        "@applitools/logger": "2.0.18",
-        "@applitools/req": "1.7.2",
-        "@applitools/utils": "1.7.4",
+        "@applitools/image": "1.1.14",
+        "@applitools/logger": "2.0.19",
+        "@applitools/req": "1.7.3",
+        "@applitools/utils": "1.7.5",
         "abort-controller": "3.0.0",
         "throat": "6.0.2"
       },
@@ -152,6 +154,7 @@
       "resolved": "https://registry.npmjs.org/@applitools/css-tree/-/css-tree-1.1.4.tgz",
       "integrity": "sha512-rH3aq/dkTweEUgS/MKuthD79CZDqpQVJlqmxqVxLZVAzbeFxYdTG/gnfG0zj6YJ025jzcPH2ktdW16Rl3QLutg==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "mdn-data": "2.1.0",
         "source-map-js": "1.0.1"
@@ -165,15 +168,17 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
       "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@applitools/dom-capture": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@applitools/dom-capture/-/dom-capture-11.5.0.tgz",
-      "integrity": "sha512-frsa+nztrxN0YyfnFNQ3fxs6Q8A93YmtqWw7v2rywv2vGk0bo1VzobFbfIFvwHEwk+oghobV+w94NdYk9jPVZA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/@applitools/dom-capture/-/dom-capture-11.5.1.tgz",
+      "integrity": "sha512-Pdhmjk/+ozWZRgTRdsX8xyZC7QG64BCQ4VaaY+J5WOzoV/Nkuh4hkEQAOaS4klvfG+BEUZQixbJbBD1OBg38oA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@applitools/dom-shared": "1.0.15",
         "@applitools/functional-commons": "1.6.0"
@@ -187,15 +192,17 @@
       "resolved": "https://registry.npmjs.org/@applitools/dom-shared/-/dom-shared-1.0.15.tgz",
       "integrity": "sha512-XN77SPfzXriU1x6gTcublSe0yUJHxlYwHesOnWQov2dMVfHx7y3qp0yrjdVC7LO2bDIJIzDlPJRhfg2otlbxig==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "engines": {
         "node": ">=12.13.0"
       }
     },
     "node_modules/@applitools/dom-snapshot": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@applitools/dom-snapshot/-/dom-snapshot-4.11.6.tgz",
-      "integrity": "sha512-RCG5KVNK20WFzudtDRGzWzyzLA1ScAL/ibV2nAMrWOB6mnznbHszH+q66tFmINmNUNl3ruba8edEx7P820pZbA==",
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/@applitools/dom-snapshot/-/dom-snapshot-4.11.9.tgz",
+      "integrity": "sha512-EizetOuZ1vGhBDz79k+v6Mn5DE7yf5S7G+JwjokJWGoUJSYB17SmU9fTkjBzUEd2stwa0YYbPgfC30mVdrhAkw==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@applitools/css-tree": "1.1.4",
         "@applitools/dom-shared": "1.0.15",
@@ -207,14 +214,15 @@
       }
     },
     "node_modules/@applitools/driver": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@applitools/driver/-/driver-1.19.6.tgz",
-      "integrity": "sha512-pWiQccHvSscUISMxuqO7i/I6ROnvhrJ8fjQ+ZTLhZPSmdvC9AhCyboG9qfRPAPPSFJxsP8gWm1JeQ7K0uAVmgg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@applitools/driver/-/driver-1.20.0.tgz",
+      "integrity": "sha512-GvlkMoqDuAwzzr/hYgRdqlzRGoQL6ZxP2ahaj+CL8HbVyWImZt81KpcD66pexjraIg8djzIaS4cAnLIL703FKA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/logger": "2.0.18",
-        "@applitools/snippets": "2.6.1",
-        "@applitools/utils": "1.7.4",
+        "@applitools/logger": "2.0.19",
+        "@applitools/snippets": "2.6.2",
+        "@applitools/utils": "1.7.5",
         "semver": "7.6.2"
       },
       "engines": {
@@ -222,19 +230,20 @@
       }
     },
     "node_modules/@applitools/ec-client": {
-      "version": "1.9.12",
-      "resolved": "https://registry.npmjs.org/@applitools/ec-client/-/ec-client-1.9.12.tgz",
-      "integrity": "sha512-NWYrsC/ZBMsTXwJAv5vXnrEqxcOuBNAzmIThpp4j06XiC8RSXUZlfe5WoFpLn694FYyODQNOu/DNNn89W2gERw==",
+      "version": "1.9.14",
+      "resolved": "https://registry.npmjs.org/@applitools/ec-client/-/ec-client-1.9.14.tgz",
+      "integrity": "sha512-JJaxSzIa/ktF2HMBtL+mjXRurM8kJM9TCWj72XDbibZCHYFeQOLcEtPxmxZUCEAP0TwC7mibR4eoubrZd2aUhg==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/core-base": "1.19.1",
-        "@applitools/driver": "1.19.6",
-        "@applitools/logger": "2.0.18",
-        "@applitools/req": "1.7.2",
-        "@applitools/socket": "1.1.18",
-        "@applitools/spec-driver-webdriver": "1.1.18",
-        "@applitools/tunnel-client": "1.5.8",
-        "@applitools/utils": "1.7.4",
+        "@applitools/core-base": "1.19.2",
+        "@applitools/driver": "1.20.0",
+        "@applitools/logger": "2.0.19",
+        "@applitools/req": "1.7.3",
+        "@applitools/socket": "1.1.19",
+        "@applitools/spec-driver-webdriver": "1.1.20",
+        "@applitools/tunnel-client": "1.5.9",
+        "@applitools/utils": "1.7.5",
         "abort-controller": "3.0.0",
         "webdriver": "7.31.1",
         "yargs": "^17.7.2"
@@ -252,6 +261,7 @@
       "resolved": "https://registry.npmjs.org/@applitools/eg-frpc/-/eg-frpc-1.0.5.tgz",
       "integrity": "sha512-9qUNiCK3R3VKxIAaLr5HO5QnUx6TioLFkJ2JcpU1ZqefApt1X2bdfS7eA4TGDXDWv/a0OIl2Lddzuo5/h3vbTw==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "engines": {
         "node": ">=12.13.0"
       }
@@ -261,6 +271,7 @@
       "resolved": "https://registry.npmjs.org/@applitools/eg-socks5-proxy-server/-/eg-socks5-proxy-server-0.5.6.tgz",
       "integrity": "sha512-SjjDBFeiKspX3nHKOoSQ+l4JUiJK3xJiWAEaR8b+GuMvnGFLnrvAECHhuXXG00+LwBJM8WKmfxEe17nvZe+nhg==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "binary": "^0.3.0",
         "is-localhost-ip": "^2.0.0"
@@ -274,6 +285,7 @@
       "resolved": "https://registry.npmjs.org/@applitools/execution-grid-tunnel/-/execution-grid-tunnel-3.0.8.tgz",
       "integrity": "sha512-4S6NcpxELH4NXketD3g6VUhWDUCuwAm4F1sCZdZLpPWOSMu5QwQDYUoe6/4t5KuktTQ4K7N90NmTzQrxiFtDKA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@applitools/eg-frpc": "1.0.5",
         "@applitools/eg-socks5-proxy-server": "^0.5.5",
@@ -302,6 +314,7 @@
       "resolved": "https://registry.npmjs.org/@applitools/logger/-/logger-1.1.53.tgz",
       "integrity": "sha512-4mlzYxc0MgM3WIxEwKqIjn9W7G7kMtQc2bFRxozViKOXypTfr72j8iODs88wcetP0GsXtplhZQ5/6aZN5WY9ug==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@applitools/utils": "1.3.36",
         "chalk": "4.1.2",
@@ -316,6 +329,7 @@
       "resolved": "https://registry.npmjs.org/@applitools/utils/-/utils-1.3.36.tgz",
       "integrity": "sha512-eROEssh7wIW+V87PvLiHI2hUPxqoBxXFMRx3+z5qOZqXUPSR1Uz7EMFwxZcDDR7T6C3O3UDckB2aVB5fJAg5JA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "engines": {
         "node": ">=12.13.0"
       }
@@ -325,6 +339,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -338,28 +353,30 @@
       }
     },
     "node_modules/@applitools/eyes": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@applitools/eyes/-/eyes-1.26.1.tgz",
-      "integrity": "sha512-AQFv7e5SpAYNmEaSf34W8rkoLuxBuFIXIne01w1PS4alkoZC9vVemM1y3RM3Gpb26MtpfLz/m6/rBeVBWALLnw==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@applitools/eyes/-/eyes-1.27.0.tgz",
+      "integrity": "sha512-+NtRMf5PFP/sokW8NqfnsYOJk5NCWbHtmKLZfgMK+BJtU436GUwMJngUGC/FfFT2+II44ZEQ8koMvf2Eu+lzVA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/core": "4.22.1",
-        "@applitools/logger": "2.0.18",
-        "@applitools/utils": "1.7.4"
+        "@applitools/core": "4.24.0",
+        "@applitools/logger": "2.0.19",
+        "@applitools/utils": "1.7.5"
       },
       "engines": {
         "node": ">=12.13.0"
       }
     },
     "node_modules/@applitools/eyes-playwright": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/@applitools/eyes-playwright/-/eyes-playwright-1.30.2.tgz",
-      "integrity": "sha512-63aZOG0RoHvUF89NV99yrunmYKUeYGPpyXhdcXO4kw3ryZRREb2ddAholEF9oCOAyfh4L+8CHLnuFDtJLpMKcA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@applitools/eyes-playwright/-/eyes-playwright-1.32.0.tgz",
+      "integrity": "sha512-pa6o8fK6S7WfAyOqCCkHUapnEqGnRzrwCvWnnsrRxMvQU4m/WE1ZS+wISAoz8Qp/n4R5VIoclq7u2bROztCFDg==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/eyes": "1.26.1",
-        "@applitools/spec-driver-playwright": "1.5.1",
-        "@applitools/utils": "1.7.4",
+        "@applitools/eyes": "1.27.0",
+        "@applitools/spec-driver-playwright": "1.5.3",
+        "@applitools/utils": "1.7.5",
         "@inquirer/prompts": "7.0.1",
         "chalk": "4.1.2",
         "yargs": "17.7.2"
@@ -388,17 +405,19 @@
       "resolved": "https://registry.npmjs.org/@applitools/functional-commons/-/functional-commons-1.6.0.tgz",
       "integrity": "sha512-fwiF0CbeYHDEOTD/NKaFgaI8LvRcGYG2GaJJiRwcedKko16sQ8F3TK5wXfj2Ytjf+8gjwHwsEEX550z3yvDWxA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@applitools/image": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@applitools/image/-/image-1.1.13.tgz",
-      "integrity": "sha512-oeSnsTJxhD6juNlWufeWsiWV9dbS0a3OL75/r/Bo2yauAi6AsRMDeh+McXJfYlf1NVZbrVG0+vNXn52mDVEIyw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@applitools/image/-/image-1.1.14.tgz",
+      "integrity": "sha512-dgCPvJTNFpf5FJYc/BRNrQqovqNIhQiQOKoeV3Ld/RtjbeiIJRqcpAML/HbbCDvBXHushtY4Ie8Q38QxgNWi7A==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/utils": "1.7.4",
+        "@applitools/utils": "1.7.5",
         "bmpimagejs": "1.0.4",
         "jpeg-js": "0.4.4",
         "omggif": "1.0.10",
@@ -409,12 +428,13 @@
       }
     },
     "node_modules/@applitools/logger": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@applitools/logger/-/logger-2.0.18.tgz",
-      "integrity": "sha512-d54OTreCXE+G9qUxiPDHHBzwof3EnXPrADdZ7ToB9AoI+kOgs/v6wjMx0ghAoXyyOiLvlvJnmdHSyJssRdv5GA==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@applitools/logger/-/logger-2.0.19.tgz",
+      "integrity": "sha512-MLuI7rgr79pRHH28bPtEkVQZww3v5+UinnSKfvaQvxeOg8AgyhIm+BZTf0LwIRw/HAGM9b1J+DQfNQ4+UYmUow==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/utils": "1.7.4",
+        "@applitools/utils": "1.7.5",
         "chalk": "4.1.2",
         "debug": "4.3.4"
       },
@@ -423,26 +443,28 @@
       }
     },
     "node_modules/@applitools/nml-client": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@applitools/nml-client/-/nml-client-1.8.16.tgz",
-      "integrity": "sha512-TyK02AN8TP7ffyoUHWcr19KK6P1GxPG9Drzze1g8IVWKrXBjCodBYYJrA5rHPvZdQZoAUQYskgzsxl61EQLURQ==",
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/@applitools/nml-client/-/nml-client-1.8.18.tgz",
+      "integrity": "sha512-YT+mLOrdD24aexHMgHq57C8XdJo2/4kL/PIffSfNfYPEhIqfMjE/MRnJnvRjLV5/H3bzwaAP4kLQUWb7h1Iulg==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/logger": "2.0.18",
-        "@applitools/req": "1.7.2",
-        "@applitools/utils": "1.7.4"
+        "@applitools/logger": "2.0.19",
+        "@applitools/req": "1.7.3",
+        "@applitools/utils": "1.7.5"
       },
       "engines": {
         "node": ">=12.13.0"
       }
     },
     "node_modules/@applitools/req": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@applitools/req/-/req-1.7.2.tgz",
-      "integrity": "sha512-L0tjPFGEJFAEGaifqtmtCghjkG7M0wnEwfzbHi6O+ThtTCbg4JSDRTaNvA+PLXQoS0mFvajG40/t5a4EgAG7QQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@applitools/req/-/req-1.7.3.tgz",
+      "integrity": "sha512-vhQDJMWss1q4yRgVWWrEK0YdqT9GkDSEwY/WfSnPV2s1PxOLNfwQKE37mVBocuyom/p2aC0J43N0QiIZygTX7w==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/utils": "1.7.4",
+        "@applitools/utils": "1.7.5",
         "abort-controller": "3.0.0",
         "http-proxy-agent": "5.0.0",
         "https-proxy-agent": "5.0.1",
@@ -457,6 +479,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
       "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -471,50 +494,54 @@
       }
     },
     "node_modules/@applitools/screenshoter": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/@applitools/screenshoter/-/screenshoter-3.9.4.tgz",
-      "integrity": "sha512-4YlS8H4uy+Euvc6sn4wtwcdogKu09tPsNTyTnEy+7Bmqf9OFt2u4Pv1U19HBJ7ffmrkhH2PN9leFL7q7AQSEog==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@applitools/screenshoter/-/screenshoter-3.10.0.tgz",
+      "integrity": "sha512-Woz9sPt2TR47WNIBV3iuSan9p2tET0LHMF00tDpkMBYJqZprAKOgy7T4hGneG23bNmSgIGU86arw+iSchibWqA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/image": "1.1.13",
-        "@applitools/logger": "2.0.18",
-        "@applitools/snippets": "2.6.1",
-        "@applitools/utils": "1.7.4"
+        "@applitools/image": "1.1.14",
+        "@applitools/logger": "2.0.19",
+        "@applitools/snippets": "2.6.2",
+        "@applitools/utils": "1.7.5"
       },
       "engines": {
         "node": ">=12.13.0"
       }
     },
     "node_modules/@applitools/snippets": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@applitools/snippets/-/snippets-2.6.1.tgz",
-      "integrity": "sha512-j82EWrBBIVW6bjxdbI4+vbr+qee6h8l7vI8MYHM54OVRynxS2jEWwil4Rb6LmH9l7OTsGSMgbeFfjrcRMawpEg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@applitools/snippets/-/snippets-2.6.2.tgz",
+      "integrity": "sha512-r5CHjta0pWiQv+rMrdlgwTYq+2XMLrE4CQqsow9ZOOXBdnNgFTcDZlpoDbcWkep+s6EOd/BRMOJNjZPREgjfxA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "engines": {
         "node": ">=12.13.0"
       }
     },
     "node_modules/@applitools/socket": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@applitools/socket/-/socket-1.1.18.tgz",
-      "integrity": "sha512-EMI/MMfVH38ucuZhFWOTUR8cPvuoP9b+xi5yBJF8uLlJjxQEmGnvm+Pm3s9o3mfxQzDRddYGtpIo3TTZhMVZdQ==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@applitools/socket/-/socket-1.1.19.tgz",
+      "integrity": "sha512-mBpNTAr8uHEmYv6a291Eqp9ErVWfLG8C+zFUjs4gzIYimtXn11JLxCIqy9FYfRQAz9nWMXdT+vxQtfQx84BcDw==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/logger": "2.0.18",
-        "@applitools/utils": "1.7.4"
+        "@applitools/logger": "2.0.19",
+        "@applitools/utils": "1.7.5"
       },
       "engines": {
         "node": ">=12.13.0"
       }
     },
     "node_modules/@applitools/spec-driver-playwright": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@applitools/spec-driver-playwright/-/spec-driver-playwright-1.5.1.tgz",
-      "integrity": "sha512-a9hj34faK8LwyOfkujJCT9V9If3tKsBEEV6jjGx5yVtD2dGUBVy+Tl9KeVohOKHRqSLuyLWU+bM//uZ7qpJfQQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@applitools/spec-driver-playwright/-/spec-driver-playwright-1.5.3.tgz",
+      "integrity": "sha512-3BVaNngv75g9aI/aPD0BpJaWY9tLUvN56TvTStjRK0RGGTG+jkZtWrE4ZlTuQ8AS8QmzTyfQBjupArtxOIrezA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/driver": "1.19.6",
-        "@applitools/utils": "1.7.4"
+        "@applitools/driver": "1.20.0",
+        "@applitools/utils": "1.7.5"
       },
       "engines": {
         "node": ">=12.13.0"
@@ -524,13 +551,14 @@
       }
     },
     "node_modules/@applitools/spec-driver-webdriver": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@applitools/spec-driver-webdriver/-/spec-driver-webdriver-1.1.18.tgz",
-      "integrity": "sha512-aC+HlPNQDSX/9QlujER/lJIb3H+PEELBNA0qvZykOepJbxb846bOdnFbW1HEtZiMXHOd2dX/c33oT+5ymn62oQ==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@applitools/spec-driver-webdriver/-/spec-driver-webdriver-1.1.20.tgz",
+      "integrity": "sha512-NNjwCooXKD6YpFaopjeWrL1veFWmoOgDCsEVrx1ozyc1jrJNn0OfzkCi0K0+FfIRbS2otG+S9NiSUQy2SsnDog==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@applitools/driver": "1.19.6",
-        "@applitools/utils": "1.7.4",
+        "@applitools/driver": "1.20.0",
+        "@applitools/utils": "1.7.5",
         "http-proxy-agent": "5.0.0",
         "https-proxy-agent": "5.0.1"
       },
@@ -542,16 +570,17 @@
       }
     },
     "node_modules/@applitools/tunnel-client": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@applitools/tunnel-client/-/tunnel-client-1.5.8.tgz",
-      "integrity": "sha512-SJByl2/I0NftENw5NvW+nHN+Vq64b0aeTsdCTYKhDhJBWqPEkGYwRR5ziYpk8MWYsL2hWcPUfg/S/hS+M3zmDg==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@applitools/tunnel-client/-/tunnel-client-1.5.9.tgz",
+      "integrity": "sha512-XS+9jEu+cAktX38DmJS97fv1kBSzPgDpKvc0L3IOkHpFKzG9SWacSthwq307EprUKSBhMcDw0wYTYF2M36l+FA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@applitools/execution-grid-tunnel": "3.0.8",
-        "@applitools/logger": "2.0.18",
-        "@applitools/req": "1.7.2",
-        "@applitools/socket": "1.1.18",
-        "@applitools/utils": "1.7.4",
+        "@applitools/logger": "2.0.19",
+        "@applitools/req": "1.7.3",
+        "@applitools/socket": "1.1.19",
+        "@applitools/utils": "1.7.5",
         "abort-controller": "3.0.0",
         "yargs": "17.7.2"
       },
@@ -563,16 +592,17 @@
       }
     },
     "node_modules/@applitools/ufg-client": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@applitools/ufg-client/-/ufg-client-1.13.1.tgz",
-      "integrity": "sha512-tzuiz5dJm8x+BR/YqGj45j+OZADb0S43XDKS41/hQ+L/xw+gFxwdWiqWn6zRO9OMAHQzTd7Sh2yFuYVCYF7Ieg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@applitools/ufg-client/-/ufg-client-1.14.0.tgz",
+      "integrity": "sha512-gcOCYt163IVJuKXA4BpnvUf5OpZXP5A6dPkt+qPaTeid+j9JHF0Q2YaEjVY2YfMt87eswt4iij2l7m8PpWeiZQ==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@applitools/css-tree": "1.1.4",
-        "@applitools/image": "1.1.13",
-        "@applitools/logger": "2.0.18",
-        "@applitools/req": "1.7.2",
-        "@applitools/utils": "1.7.4",
+        "@applitools/image": "1.1.14",
+        "@applitools/logger": "2.0.19",
+        "@applitools/req": "1.7.3",
+        "@applitools/utils": "1.7.5",
         "@xmldom/xmldom": "0.8.10",
         "abort-controller": "3.0.0",
         "throat": "6.0.2"
@@ -582,10 +612,11 @@
       }
     },
     "node_modules/@applitools/utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@applitools/utils/-/utils-1.7.4.tgz",
-      "integrity": "sha512-qgJqx2yjlJBf79YyFehf1nSp4AXOdzJn3POQyg8CMWV0YH6HsjAfJjYaNrbXFcGYCSpPEJGhGehxC7GVKHX3YA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@applitools/utils/-/utils-1.7.5.tgz",
+      "integrity": "sha512-T02rEmbTPdmQcwKwaw1Issc6KIrw0SjsbjPLgjY2bF/maD+mTBlfq2p95ht+B897reaiMByD7DjCdmOpBtbRSw==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "engines": {
         "node": ">=12.13.0"
       }
@@ -662,6 +693,7 @@
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
       "integrity": "sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
@@ -673,6 +705,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -688,25 +721,29 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
       "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
       "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
       "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-json-stringify": "^5.7.0"
       }
@@ -716,6 +753,7 @@
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
       "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
@@ -1423,6 +1461,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1448,6 +1487,7 @@
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -1460,6 +1500,7 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -1469,6 +1510,7 @@
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -1481,6 +1523,7 @@
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/minimatch": "^5.1.2",
         "@types/node": "*"
@@ -1490,13 +1533,15 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1505,7 +1550,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
@@ -1541,6 +1587,7 @@
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1549,7 +1596,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
@@ -1562,6 +1610,7 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
       "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1596,6 +1645,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.31.1.tgz",
       "integrity": "sha512-WAfswbCatwiaDVqy6kfF/5T8/WS/US/SRhBGUFrfBuGMIe+RRoHgy7jURFWSvUIE7CNHj8yvs46fLUcxhXjzcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/glob": "^8.1.0",
         "@wdio/logger": "7.26.0",
@@ -1613,6 +1663,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1623,6 +1674,7 @@
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1642,6 +1694,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1654,6 +1707,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-7.26.0.tgz",
       "integrity": "sha512-kQj9s5JudAG9qB+zAAcYGPHVfATl2oqKgqj47yjehOQ1zzG33xmtL1ArFbQKWhDG32y1A8sN6b0pIqBEIwgg8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "loglevel": "^1.6.0",
@@ -1669,6 +1723,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.27.0.tgz",
       "integrity": "sha512-hT/U22R5i3HhwPjkaKAG0yd59eaOaZB0eibRj2+esCImkb5Y6rg8FirrlYRxIGFVBl0+xZV0jKHzR5+o097nvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -1678,6 +1733,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.30.2.tgz",
       "integrity": "sha512-uZ8o7FX8RyBsaXiOWa59UKTCHTtADNvOArYTcHNEIzt+rh4JdB/uwqfc8y4TCNA2kYm7PWaQpUFwpStLeg0H1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.0",
         "got": "^11.8.1"
@@ -1699,6 +1755,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
       "integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1708,6 +1765,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.30.2.tgz",
       "integrity": "sha512-np7I+smszFUennbQKdzbMN/zUL3s3EZq9pCCUcTRjjs9TE4tnn0wfmGdoz2o7REYu6kn9NfFFJyVIM2VtBbKEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "7.26.0",
         "@wdio/types": "7.30.2",
@@ -1770,6 +1828,7 @@
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
       "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1779,6 +1838,7 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -1790,7 +1850,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.7.1",
@@ -1819,6 +1880,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "4"
       },
@@ -1847,6 +1909,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1864,6 +1927,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1879,13 +1943,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
       "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -1949,6 +2015,7 @@
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1995,6 +2062,7 @@
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.4.0.tgz",
       "integrity": "sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@fastify/error": "^3.3.0",
         "fastq": "^1.17.1"
@@ -2011,6 +2079,7 @@
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffers": "~0.1.1",
         "chainsaw": "~0.1.0"
@@ -2023,13 +2092,15 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bmpimagejs": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bmpimagejs/-/bmpimagejs-1.0.4.tgz",
       "integrity": "sha512-21oKU7kbRt2OgOOj7rdiNr/yznDNUQ585plxR00rsmECcZr+6O1oCwB8OIoSHk/bDhbG8mFXIdeQuCPHgZ6QBw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2077,7 +2148,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/buffers": {
       "version": "0.1.1",
@@ -2104,6 +2176,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
       }
@@ -2113,6 +2186,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -2159,6 +2233,7 @@
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
       "dev": true,
+      "license": "MIT/X11",
       "dependencies": {
         "traverse": ">=0.3.0 <0.4"
       },
@@ -2238,6 +2313,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2252,6 +2328,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2269,6 +2346,7 @@
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -2307,6 +2385,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -2322,6 +2401,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2356,6 +2436,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -2395,6 +2476,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -2410,6 +2492,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2428,6 +2511,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2437,6 +2521,7 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -2458,6 +2543,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -2482,6 +2568,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -2491,6 +2578,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2675,6 +2763,7 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2709,13 +2798,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
       "integrity": "sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2734,6 +2825,7 @@
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.16.1.tgz",
       "integrity": "sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@fastify/merge-json-schemas": "^0.1.0",
         "ajv": "^8.10.0",
@@ -2749,6 +2841,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2765,6 +2858,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -2781,13 +2875,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
       "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -2800,6 +2896,7 @@
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
@@ -2809,6 +2906,7 @@
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
       "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2817,7 +2915,8 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
       "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastify": {
       "version": "4.28.1",
@@ -2834,6 +2933,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@fastify/ajv-compiler": "^3.5.0",
         "@fastify/error": "^3.4.0",
@@ -2857,7 +2957,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
       "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -2883,6 +2984,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -2919,6 +3021,7 @@
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
       "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
@@ -2933,6 +3036,7 @@
       "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
       "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "commander": "^5.1.0",
@@ -2983,6 +3087,7 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -2995,6 +3100,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3037,6 +3143,7 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3046,6 +3153,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -3108,6 +3216,7 @@
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -3182,13 +3291,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -3203,6 +3314,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -3216,6 +3328,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -3229,6 +3342,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3291,6 +3405,7 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz",
       "integrity": "sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
@@ -3300,6 +3415,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -3339,6 +3455,7 @@
       "resolved": "https://registry.npmjs.org/is-localhost-ip/-/is-localhost-ip-2.0.0.tgz",
       "integrity": "sha512-vlgs2cSgMOfnKU8c1ewgKPyum9rVrjjLLW2HBdL5i0iAJjOs8NY55ZBd/hqUTaYR0EO9CKZd3hVSC2HlIbygTQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -3362,7 +3479,8 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-cookie": {
       "version": "3.0.5",
@@ -3400,6 +3518,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
       "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
@@ -3430,6 +3549,7 @@
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.30.0.tgz",
       "integrity": "sha512-X/u76z4JtDVq10u1JA5UQfatPxgPaVDMYTrgHyiTpGN2z4TMEJkIHsoSBBSg9SWZEIXTKsi9kHgiQ9o3Y/4yog==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3455,6 +3575,7 @@
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
       "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "cookie": "^0.7.0",
         "process-warning": "^3.0.0",
@@ -3492,6 +3613,7 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -3504,7 +3626,8 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3522,6 +3645,7 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3530,13 +3654,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.1.0.tgz",
       "integrity": "sha512-dbAWH6A+2NGuVJlQFrTKHJc07Vqn5frnhyTOGz+7BsK7V2hHdoBcwoiyV3QVhLHYpM/zqe2OSUn5ZWbVXLBB8A==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -3667,7 +3793,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
       "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -3684,6 +3811,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -3693,6 +3821,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3728,6 +3857,7 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3747,13 +3877,15 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
       "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3807,6 +3939,7 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3816,6 +3949,7 @@
       "resolved": "https://registry.npmjs.org/p-iteration/-/p-iteration-1.1.8.tgz",
       "integrity": "sha512-IMFBSDIYcPNnW7uWYGrBqmvTiq7W0uB0fJn6shQZs7dlF3OvrHOre+JT9ikSZ7gZS3vWqclVgoQSvToJrns7uQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3855,6 +3989,7 @@
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -3867,7 +4002,8 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3918,6 +4054,7 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
       "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -3940,6 +4077,7 @@
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
       "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
       }
@@ -3948,13 +4086,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pino/node_modules/process-warning": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
       "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.48.2",
@@ -3990,7 +4130,8 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/png-async/-/png-async-0.9.4.tgz",
       "integrity": "sha512-B//AXX9TkneKfgtOpT1mdUnnhk2BImGD+a98vImsMU8uo1dBeHyW/kM2erWZ/CsYteTPU/xKG+t6T62heHkC3A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.4.35",
@@ -4040,7 +4181,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4057,6 +4199,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -4070,6 +4213,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
       "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4124,13 +4268,15 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4179,6 +4325,7 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -4193,6 +4340,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4202,6 +4350,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4210,7 +4359,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4234,6 +4384,7 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -4246,6 +4397,7 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
       "integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -4255,6 +4407,7 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -4273,7 +4426,8 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -4318,6 +4472,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
       "integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ret": "~0.4.0"
       }
@@ -4327,6 +4482,7 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -4349,13 +4505,15 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4367,7 +4525,8 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4395,6 +4554,7 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4421,6 +4581,7 @@
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
       "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -4430,6 +4591,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4447,6 +4609,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4468,6 +4631,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
@@ -4556,6 +4720,7 @@
       "engines": [
         "node"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "bluebird": "^3.5.1",
@@ -4576,6 +4741,7 @@
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -4584,7 +4750,8 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
       "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -4603,6 +4770,7 @@
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
       "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -4611,13 +4779,15 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
       "dev": true,
+      "license": "MIT/X11",
       "engines": {
         "node": "*"
       }
@@ -4678,7 +4848,8 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -4728,6 +4899,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4737,6 +4909,7 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -4746,6 +4919,7 @@
       "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.31.1.tgz",
       "integrity": "sha512-nCdJLxRnYvOMFqTEX7sqQtF/hV/Jgov0Y6ICeOm1DMTlZSRRDaUsBMlEAPkEwif9uBJYdM0znv8qzfX358AGqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.0.0",
         "@wdio/config": "7.31.1",
@@ -4766,6 +4940,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
       "integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4774,13 +4949,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -4826,6 +5003,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4847,6 +5025,7 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -4856,6 +5035,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4874,6 +5054,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.0.0"
   },
   "devDependencies": {
-    "@applitools/eyes-playwright": "1.30.2",
+    "@applitools/eyes-playwright": "1.32.0",
     "@playwright/test": "^1.48.2",
     "@types/mocha": "^10.0.6",
     "@types/node": "20.2.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,8 +39,7 @@ export default defineConfig<EyesFixture>({
     baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000/",
     /* Configuration for Eyes VisualAI */
     eyesConfig: {
-      /* The following and other configuration parameters are documented at: <url> */
-      apiKey: process.env.APPLITOOLS_API_KEY,
+      /* The following and other configuration parameters are documented at: https://applitools.com/tutorials/playwright/api/overview */
       serverUrl: "https://testeyes.applitools.com/",
       // type: "ufg", // Uncomment this and browsersInfo to use Ultrafast Grid instead of "classic" mode, which is the default, which uses Playwright's browser settings.
       // browsersInfo: [

--- a/tests/applitools-examples.spec.ts
+++ b/tests/applitools-examples.spec.ts
@@ -60,9 +60,12 @@ test.describe("Applitools Examples", () => {
     // });
     // await eyes.check("small visual changes test");
 
-    //Users can use a layoutRegion(s) or ignoreRegion(s) if these visual diffs are intentional.
+    // Users can use a layoutRegion(s) or ignoreRegion(s) if these visual diffs are intentional.
     // await eyes.check("small visual changes test after", {
-    //   layoutRegions: ["#log-in", "#username"],
+    //   layoutRegions: [
+    //      page.getByRole('button', { name: 'Sign in' }),
+    //      page.getByPlaceholder('Enter your username')
+    //   ]
     // });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     "noEmit": true,
     "incremental": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"


### PR DESCRIPTION
I suggest the following changes:
1. Upgrade to the latest version (1.32.0) of Eyes-Playwright, which is the formal release version. This will change baselines from the previous beta version, since we made some internal changes to the name of the test that dictates the baseline.
2. Update URL to API reference in `playwright.config.ts`. We missed this in our release, so our script still has the placeholder (there is another place in the eyes-setup console output where the URL is fine). This will be fixed in the next patch version.
3. Remove `process.env.APPLITOOLS_API_KEY` from `playwright.config.ts`. This env var is read automatically.
4. Specify layout regions with Playwright locators. This is just a suggestion. It's a bit more verbose, but serves as a good demonstration that Eyes-Playwright is immersed with the Playwright constructs.
5. TypeScript module resolution is changed to `NodeNext`, in order to get types to be recognized in VSCode.